### PR TITLE
[1.21.1] Compatability with WATUT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -124,6 +124,9 @@ dependencies {
     // The group id is ignored when searching -- in this case, it is "blank"
     // implementation "blank:coolmod-${mc_version}:${coolmod_version}"
 
+    //unsure where to find a maven for watut-neoforge, so using local download
+    compileOnly files("libs/watut-neoforge-${dev_compat_watut_version}.jar")
+
     // Example mod dependency using a file as dependency
     // implementation files("libs/coolmod-${mc_version}-${coolmod_version}.jar")
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -43,3 +43,5 @@ mod_group_id=com.vladmarica.betterpingdisplay
 mod_authors=Quintinity
 # The description of the mod. This is a simple multiline text string that is used for display purposes in the mod list.
 mod_description=Shows the actual ping number instead of just bars in the player list.
+
+dev_compat_watut_version=1.21.0-1.2.7

--- a/src/main/java/com/vladmarica/betterpingdisplay/client/RenderPingHandler.java
+++ b/src/main/java/com/vladmarica/betterpingdisplay/client/RenderPingHandler.java
@@ -26,17 +26,23 @@ public final class RenderPingHandler {
             ? PingColors.getColor(player.getLatency())
             : Config.getTextColor();
 
+    boolean renderPingBars = Config.shouldRenderPingBars();
+
     int textX = width + x - pingStringWidth;
-    if (Config.shouldRenderPingBars()) {
-      textX += PING_TEXT_RENDER_OFFSET;
+    if (renderPingBars) {
+        textX += PING_TEXT_RENDER_OFFSET;
     }
 
-    // Draw the ping text
-    graphics.drawString(mc.font, pingString, textX, y, pingTextColor);
+    boolean suppressedByWATUT = WATUTCompat.shouldRenderIdleState(overlay, graphics, width, x, y, player);
 
-    // Draw the ping bars
-    if (Config.shouldRenderPingBars()) {
-      ((PlayerTabOverlayInvoker) overlay).invokeRenderPingIcon(graphics, width, x, y, player);
+    // Draw ping text when either bars are enabled or WATUT doesn't suppress it
+    if (renderPingBars || !suppressedByWATUT) {
+        graphics.drawString(mc.font, pingString, textX, y, pingTextColor);
+    }
+
+    // Draw ping icon only when bars are enabled and not suppressed
+    if (renderPingBars && !suppressedByWATUT) {
+        ((PlayerTabOverlayInvoker) overlay).invokeRenderPingIcon(graphics, width, x, y, player);
     }
   }
 }

--- a/src/main/java/com/vladmarica/betterpingdisplay/client/WATUTCompat.java
+++ b/src/main/java/com/vladmarica/betterpingdisplay/client/WATUTCompat.java
@@ -1,0 +1,23 @@
+package com.vladmarica.betterpingdisplay.client;
+
+import com.corosus.watut.WatutMod;
+
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.PlayerTabOverlay;
+import net.minecraft.client.multiplayer.PlayerInfo;
+import net.neoforged.fml.ModList;
+
+public class WATUTCompat {
+  public static final String WATUT_MOD_ID = "watut";
+
+  public static boolean shouldRenderIdleState(PlayerTabOverlay overlay, GuiGraphics graphics, int width, int x, int y, PlayerInfo player) {
+    if (!isWATUTModLoaded()) return false;
+
+    // Check if WATUT's "ZZ" ping replacement is enabled
+    return WatutMod.getPlayerStatusManagerClient().renderPingIconHook(overlay, graphics, width, x, y, player);
+  }
+
+  private static boolean isWATUTModLoaded() {
+    return ModList.get().isLoaded(WATUT_MOD_ID);
+  }
+}


### PR DESCRIPTION
This PR adds compatibility with [WATUT](https://github.com/Corosauce/WATUT) by selectively disabling the ping display when a player goes AFK and allowing WATUT to replace it with the "ZZ" icon.

This PR was created from commit 8b511bfb7e468814a695b6e3d2ef2df5ed747a8d